### PR TITLE
Add scripts to start/stop the mock server easily and document their usage

### DIFF
--- a/mock_server/README.md
+++ b/mock_server/README.md
@@ -10,11 +10,19 @@ This directory contains a local mock server for frontend development using [json
    # or
    npm install --save-dev json-server
    ```
-2. **Start the mock server**:
+2. **Start the mock server** (recommended):
+   ```sh
+   ./mock_server/start_mock_server.sh
+   ```
+   Or manually:
    ```sh
    json-server --watch mock_server/db.json --port 4000
    ```
-3. The API will be available at [http://localhost:4000](http://localhost:4000)
+3. **Stop the mock server** (Linux/macOS):
+   ```sh
+   ./mock_server/stop_mock_server.sh
+   ```
+4. The API will be available at [http://localhost:4000](http://localhost:4000)
 
 ## Endpoints
 - `/players` — Player data

--- a/mock_server/start_mock_server.sh
+++ b/mock_server/start_mock_server.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Start the mock server (json-server) on port 4000
+json-server --watch mock_server/db.json --port 4000

--- a/mock_server/stop_mock_server.sh
+++ b/mock_server/stop_mock_server.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Stop the mock server running on port 4000 (Linux/macOS only)
+PID=$(lsof -ti:4000)
+if [ -n "$PID" ]; then
+  kill $PID
+  echo "Stopped mock server (PID $PID)"
+else
+  echo "No process found on port 4000."
+fi


### PR DESCRIPTION
- Add `start_mock_server.sh` and `stop_mock_server.sh` scripts for easy mock server management.
- Update `mock_server/README.md` to document script usage and manual alternatives.

Closes #83.