### PR TITLE
Plan for easy switching between mock and real backend (docs and code example)

### DIFF
--- a/mock_server/README.md
+++ b/mock_server/README.md
@@ -51,6 +51,12 @@ final response = await http.get(Uri.parse('http://localhost:4000/players'));
 
 ## Switching Between Mock and Real Backend
 - Use environment variables or config files in your frontend to toggle between the mock server and the real backend.
-- See `ApiConfig` in `lib/api.dart` for an example.
+- **Flutter example:**
+  - By default, the app uses the mock server at `http://localhost:4000`.
+  - To use the real backend, run:
+    ```sh
+    flutter run --dart-define=USE_MOCK_API=false
+    ```
+  - See `ApiConfig` in `lib/api.dart` for details.
 
 ---

--- a/space_iron_flutter/lib/api.dart
+++ b/space_iron_flutter/lib/api.dart
@@ -2,6 +2,11 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 
 /// Utility to switch between mock and real backend.
+///
+/// By default, uses the mock server at http://localhost:4000.
+/// To use the real backend, set the `USE_MOCK_API` environment variable to `false` at build time:
+///   flutter run --dart-define=USE_MOCK_API=false
+/// You can also change the real backend URL below.
 class ApiConfig {
   static const bool useMock = bool.fromEnvironment('USE_MOCK_API', defaultValue: true);
   static String get baseUrl => useMock ? 'http://localhost:4000' : 'https://your-real-backend-url.com';


### PR DESCRIPTION
- Adds documentation and code for toggling between mock and real backend in Flutter using the USE_MOCK_API environment variable.
- Updates mock_server/README.md with clear instructions for backend switching.
- See lib/api.dart for implementation details.

Closes #83.